### PR TITLE
feature/vultr csi

### DIFF
--- a/vultr-csi/templates/storageclass.yaml
+++ b/vultr-csi/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: block.csi.vultr.com


### PR DESCRIPTION
- fix(vultr-csi): use more current version, do not set default storage
- chore(build): add golang for ci
- fix(vultr-csi): bump api version of storageclass
